### PR TITLE
Use forward slashes to separate include files

### DIFF
--- a/src/win32/thread.cpp
+++ b/src/win32/thread.cpp
@@ -34,10 +34,10 @@
 #include <mutex>
 #include <atomic>
 #include <Activation.h>
-#include <wrl\client.h>
-#include <wrl\event.h>
-#include <wrl\wrappers\corewrappers.h>
-#include <wrl\ftm.h>
+#include <wrl/client.h>
+#include <wrl/event.h>
+#include <wrl/wrappers/corewrappers.h>
+#include <wrl/ftm.h>
 #include <windows.system.threading.h>
 #pragma comment(lib, "runtimeobject.lib")
 #endif


### PR DESCRIPTION
We use automatic dependency tracking for #includes, and wrl includes have to be tracked differently whenever we are cross-compiling the code.

This PR unifies such tracking. Forward slashes work just fine on Windows.