### PR TITLE
Use BOOST_DEFAULTED_FUNCTION on empty destructors

### DIFF
--- a/include/boost/thread/exceptions.hpp
+++ b/include/boost/thread/exceptions.hpp
@@ -56,8 +56,7 @@ namespace boost
         {
         }
 
-        ~thread_exception() BOOST_NOEXCEPT_OR_NOTHROW
-        {}
+        BOOST_DEFAULTED_FUNCTION(~thread_exception() BOOST_NOEXCEPT_OR_NOTHROW, {})
 
 
         int native_error() const
@@ -113,8 +112,7 @@ namespace boost
         {
         }
 
-        ~lock_error() BOOST_NOEXCEPT_OR_NOTHROW
-        {}
+        BOOST_DEFAULTED_FUNCTION(~lock_error() BOOST_NOEXCEPT_OR_NOTHROW, {})
 
     };
 
@@ -141,8 +139,7 @@ namespace boost
           }
 
 
-        ~thread_resource_error() BOOST_NOEXCEPT_OR_NOTHROW
-        {}
+        BOOST_DEFAULTED_FUNCTION(~thread_resource_error() BOOST_NOEXCEPT_OR_NOTHROW, {})
 
     };
 


### PR DESCRIPTION
The compiler-generated copy constructor and copy assignment operator are deprecated since C++11 on classes with user-declared destructors.

This change allows clean compilation with the -Wdeprecated-copy-dtor/-Wdeprecated-copy-with-user-provided-dtor flag.