### PR TITLE
Non-template function needs inline

### DIFF
--- a/include/boost/thread/experimental/parallel/v2/task_region.hpp
+++ b/include/boost/thread/experimental/parallel/v2/task_region.hpp
@@ -51,7 +51,7 @@ BOOST_THREAD_INLINE_NAMESPACE(v2)
 
   namespace detail
   {
-    void handle_task_region_exceptions(exception_list& errors)
+    inline void handle_task_region_exceptions(exception_list& errors)
     {
       try {
         throw;


### PR DESCRIPTION
This is to prevent multiple definition of the symbol when the file is included from multiple modules.